### PR TITLE
Implemented basic console variable support

### DIFF
--- a/Volt/Sandbox/src/Sandbox/Window/LogPanel.cpp
+++ b/Volt/Sandbox/src/Sandbox/Window/LogPanel.cpp
@@ -65,7 +65,7 @@ void LogPanel::UpdateMainContent()
 			{
 				auto variable = Volt::ConsoleVariableRegistry::GetVariable(strings[0]);
 
-				std::string message = strings[0] + " = ";
+				std::string message = std::string(variable->GetName()) + " = ";
 
 				if (strings.size() > 1)
 				{

--- a/Volt/Sandbox/src/Sandbox/Window/LogPanel.cpp
+++ b/Volt/Sandbox/src/Sandbox/Window/LogPanel.cpp
@@ -3,6 +3,9 @@
 
 #include <Volt/Log/Log.h>
 #include <Volt/Utility/UIUtility.h>
+#include <Volt/Utility/StringUtility.h>
+
+#include <Volt/Console/ConsoleVariableRegistry.h>
 
 namespace Utility
 {
@@ -49,9 +52,72 @@ void LogPanel::UpdateMainContent()
 	}
 
 	ImGui::SameLine();
+	ImGui::PushItemWidth(200.f);
+
+	static std::string commandStr;
+
+	if (ImGui::InputTextWithHintString("##commandLine", "Command...", &commandStr, ImGuiInputTextFlags_EnterReturnsTrue))
+	{
+		auto strings = Utility::SplitStringsByCharacter(commandStr, ' ');
+		if (!strings.empty())
+		{
+			if (Volt::ConsoleVariableRegistry::VariableExists(strings[0]))
+			{
+				auto variable = Volt::ConsoleVariableRegistry::GetVariable(strings[0]);
+
+				std::string message = strings[0] + " = ";
+
+				if (strings.size() > 1)
+				{
+					if (variable->IsFloat())
+					{
+						const float value = std::stof(strings[1]);
+						variable->Set(&value);
+					}
+					else if (variable->IsInteger())
+					{
+						const int32_t value = std::stoi(strings[1]);
+						variable->Set(&value);
+					}
+					else if (variable->IsString())
+					{
+						variable->Set(&strings[1]);
+					}
+
+					message += strings[1];
+				}
+				else
+				{
+					if (variable->IsFloat())
+					{
+						message += std::to_string(*static_cast<const float*>(variable->Get()));
+					}
+					else if (variable->IsInteger())
+					{
+						message += std::to_string(*static_cast<const int32_t*>(variable->Get()));
+					}
+					else if (variable->IsString())
+					{
+						message += *static_cast<const std::string*>(variable->Get());
+					}
+
+				}
+
+				VT_CORE_TRACE(message);
+			}
+			else
+			{
+				VT_CORE_TRACE("Command {0} not found!", strings[0]);
+			}
+		}
+
+		commandStr = "";
+	}
+
+
+	ImGui::SameLine();
 	static int32_t logLevel = 0;
 
-	ImGui::PushItemWidth(200.f);
 	if (ImGui::Combo("##level", &logLevel, "Trace\0Info\0Warning\0Error\0Critical"))
 	{
 		switch (logLevel)

--- a/Volt/Volt/src/Volt/Console/ConsoleVariableRegistry.h
+++ b/Volt/Volt/src/Volt/Console/ConsoleVariableRegistry.h
@@ -1,0 +1,151 @@
+#pragma once
+
+#include "Volt/Core/Base.h"
+
+#include <unordered_map>
+#include <string_view>
+
+namespace Volt
+{
+	class RegisteredConsoleVariableBase
+	{
+	public:
+		virtual const void* Get() const = 0;
+		virtual void Set(const void* value) = 0;
+
+		virtual std::string_view GetName() const = 0;
+		virtual std::string_view GetDescription() const = 0;
+	};
+
+	template<typename T> 
+	class RegisteredConsoleVariable : public RegisteredConsoleVariableBase
+	{
+	public:
+		RegisteredConsoleVariable(std::string_view variableName, const T& defaultValue, std::string_view description);
+
+		const void* Get() const override;
+		void Set(const void* value) override;
+
+		std::string_view GetName() const override { return m_variableName; }
+		std::string_view GetDescription() const override { return m_description; }
+
+	private:
+		T m_value;
+		std::string_view m_variableName;
+		std::string_view m_description;
+	};
+
+	template<typename T>
+	class ConsoleVariable
+	{
+	public:
+		ConsoleVariable(std::string_view variableName, const T& defaultValue, std::string_view description);
+
+		const T& GetValue() const { return *reinterpret_cast<T*>(m_variableReference->Get()); }
+		void SetValue(const T& value) { m_variableReference->Set(&value); }
+
+		T& operator=(const T& other)
+		{
+			if (this == &other)
+			{
+				return GetValue();
+			}
+
+			SetValue(other);
+		}
+
+	private:
+		Weak<RegisteredConsoleVariable<T>> m_variableReference;
+	};
+
+	template<typename T>
+	class ConsoleVariableRef
+	{
+	public:
+		ConsoleVariableRef(std::string_view variableName);
+
+		const T& GetValue() const { return *reinterpret_cast<T*>(m_variableReference->Get()); }
+		void SetValue(const T& value) { m_variableReference->Set(&value); }
+
+		T& operator=(const T& other)
+		{
+			if (this == &other)
+			{
+				return GetValue();
+			}
+
+			SetValue(other);
+		}
+
+	private:
+		Weak<RegisteredConsoleVariable<T>> m_variableReference;
+	};
+
+	class ConsoleVariableRegistry
+	{
+	public:
+		template<typename T>
+		static Weak<RegisteredConsoleVariable<T>> RegisterVariable(std::string_view variableName, const T& defaultValue, std::string_view description);
+
+		template<typename T>
+		static Weak<RegisteredConsoleVariable<T>> FindVariable(std::string_view variableName);
+
+		static std::unordered_map<std::string_view, Ref<RegisteredConsoleVariableBase>>& GetRegisteredVariables() { return s_registeredVariables; }
+
+	private:
+		inline static std::unordered_map<std::string_view, Ref<RegisteredConsoleVariableBase>> s_registeredVariables;
+	};
+
+	template<typename T>
+	inline RegisteredConsoleVariable<T>::RegisteredConsoleVariable(std::string_view variableName, const T& defaultValue, std::string_view description)
+		: m_value(defaultValue)
+	{
+	}
+
+	template<typename T>
+	inline const void* RegisteredConsoleVariable<T>::Get() const
+	{
+		return reinterpret_cast<const void*>(&m_value);
+	}
+
+	template<typename T>
+	inline void RegisteredConsoleVariable<T>::Set(const void* value)
+	{
+		m_value = *reinterpret_cast<const T*>(value);
+	}
+
+	template<typename T>
+	inline ConsoleVariable<T>::ConsoleVariable(std::string_view variableName, const T& defaultValue, std::string_view description)
+	{
+		m_variableReference = ConsoleVariableRegistry::RegisterVariable<T>(variableName, defaultValue, description);
+	}
+
+	template<typename T>
+	inline Weak<RegisteredConsoleVariable<T>> ConsoleVariableRegistry::RegisterVariable(std::string_view variableName, const T& defaultValue, std::string_view description)
+	{
+		Ref<RegisteredConsoleVariable<T>> consoleVariable = CreateRef<RegisteredConsoleVariable<T>>(variableName, defaultValue, description);
+
+		VT_CORE_ASSERT(!s_registeredVariables.contains(variableName), "Command variable with name already registered!");
+		s_registeredVariables[variableName] = consoleVariable;
+
+		return consoleVariable;
+	}
+	
+	template<typename T>
+	inline Weak<RegisteredConsoleVariable<T>> ConsoleVariableRegistry::FindVariable(std::string_view variableName)
+	{
+		if (s_registeredVariables.contains(variableName))
+		{
+			return s_registeredVariables.at(variableName);
+		}
+
+		return Weak<RegisteredConsoleVariable<T>>();
+	}
+
+	template<typename T>
+	inline ConsoleVariableRef<T>::ConsoleVariableRef(std::string_view variableName)
+	{
+		m_variableReference = ConsoleVariableRegistry::FindVariable(variableName);
+		VT_CORE_ASSERT(m_variableReference, "Variable with name not found!");
+	}
+}

--- a/Volt/Volt/src/Volt/Console/ConsoleVariableRegistry.h
+++ b/Volt/Volt/src/Volt/Console/ConsoleVariableRegistry.h
@@ -15,19 +15,30 @@ namespace Volt
 
 		virtual std::string_view GetName() const = 0;
 		virtual std::string_view GetDescription() const = 0;
+		
+		virtual bool IsInteger() const = 0;
+		virtual bool IsFloat() const = 0;
+		virtual bool IsString() const = 0;
 	};
 
-	template<typename T> 
+	template<typename T>
+	concept ValidConsoleVariableType = std::is_same_v<T, int32_t> || std::is_same_v<T, float> || std::is_same_v<T, std::string>;
+
+	template<ValidConsoleVariableType T>
 	class RegisteredConsoleVariable : public RegisteredConsoleVariableBase
 	{
 	public:
 		RegisteredConsoleVariable(std::string_view variableName, const T& defaultValue, std::string_view description);
 
-		const void* Get() const override;
+		[[nodiscard]] const void* Get() const override;
 		void Set(const void* value) override;
 
-		std::string_view GetName() const override { return m_variableName; }
-		std::string_view GetDescription() const override { return m_description; }
+		[[nodiscard]] inline std::string_view GetName() const override { return m_variableName; }
+		[[nodiscard]] inline std::string_view GetDescription() const override { return m_description; }
+
+		[[nodiscard]] inline constexpr bool IsInteger() const override { return std::is_integral_v<T>; }
+		[[nodiscard]] inline constexpr bool IsFloat() const override { return std::is_floating_point_v<T>; }
+		[[nodiscard]] inline constexpr bool IsString() const override { return std::is_same_v<T, std::string>; }
 
 	private:
 		T m_value;
@@ -35,7 +46,7 @@ namespace Volt
 		std::string_view m_description;
 	};
 
-	template<typename T>
+	template<ValidConsoleVariableType T>
 	class ConsoleVariable
 	{
 	public:
@@ -58,7 +69,7 @@ namespace Volt
 		Weak<RegisteredConsoleVariable<T>> m_variableReference;
 	};
 
-	template<typename T>
+	template<ValidConsoleVariableType T>
 	class ConsoleVariableRef
 	{
 	public:
@@ -84,43 +95,53 @@ namespace Volt
 	class ConsoleVariableRegistry
 	{
 	public:
-		template<typename T>
+		template<ValidConsoleVariableType T>
 		static Weak<RegisteredConsoleVariable<T>> RegisterVariable(std::string_view variableName, const T& defaultValue, std::string_view description);
 
-		template<typename T>
+		template<ValidConsoleVariableType T>
 		static Weak<RegisteredConsoleVariable<T>> FindVariable(std::string_view variableName);
+
+		inline static Weak<RegisteredConsoleVariableBase> GetVariable(std::string_view variableName);
+		inline static bool VariableExists(const std::string& variableName);
 
 		static std::unordered_map<std::string_view, Ref<RegisteredConsoleVariableBase>>& GetRegisteredVariables() { return s_registeredVariables; }
 
 	private:
+		ConsoleVariableRegistry() = delete;
+
 		inline static std::unordered_map<std::string_view, Ref<RegisteredConsoleVariableBase>> s_registeredVariables;
 	};
 
-	template<typename T>
+	inline bool ConsoleVariableRegistry::VariableExists(const std::string& variableName)
+	{
+		return s_registeredVariables.contains(std::string_view(variableName));
+	}
+
+	template<ValidConsoleVariableType T>
 	inline RegisteredConsoleVariable<T>::RegisteredConsoleVariable(std::string_view variableName, const T& defaultValue, std::string_view description)
 		: m_value(defaultValue)
 	{
 	}
 
-	template<typename T>
+	template<ValidConsoleVariableType T>
 	inline const void* RegisteredConsoleVariable<T>::Get() const
 	{
 		return reinterpret_cast<const void*>(&m_value);
 	}
 
-	template<typename T>
+	template<ValidConsoleVariableType T>
 	inline void RegisteredConsoleVariable<T>::Set(const void* value)
 	{
 		m_value = *reinterpret_cast<const T*>(value);
 	}
 
-	template<typename T>
+	template<ValidConsoleVariableType T>
 	inline ConsoleVariable<T>::ConsoleVariable(std::string_view variableName, const T& defaultValue, std::string_view description)
 	{
 		m_variableReference = ConsoleVariableRegistry::RegisterVariable<T>(variableName, defaultValue, description);
 	}
 
-	template<typename T>
+	template<ValidConsoleVariableType T>
 	inline Weak<RegisteredConsoleVariable<T>> ConsoleVariableRegistry::RegisterVariable(std::string_view variableName, const T& defaultValue, std::string_view description)
 	{
 		Ref<RegisteredConsoleVariable<T>> consoleVariable = CreateRef<RegisteredConsoleVariable<T>>(variableName, defaultValue, description);
@@ -131,7 +152,7 @@ namespace Volt
 		return consoleVariable;
 	}
 	
-	template<typename T>
+	template<ValidConsoleVariableType T>
 	inline Weak<RegisteredConsoleVariable<T>> ConsoleVariableRegistry::FindVariable(std::string_view variableName)
 	{
 		if (s_registeredVariables.contains(variableName))
@@ -142,10 +163,15 @@ namespace Volt
 		return Weak<RegisteredConsoleVariable<T>>();
 	}
 
-	template<typename T>
+	template<ValidConsoleVariableType T>
 	inline ConsoleVariableRef<T>::ConsoleVariableRef(std::string_view variableName)
 	{
 		m_variableReference = ConsoleVariableRegistry::FindVariable(variableName);
 		VT_CORE_ASSERT(m_variableReference, "Variable with name not found!");
+	}
+
+	inline Weak<RegisteredConsoleVariableBase> ConsoleVariableRegistry::GetVariable(std::string_view variableName)
+	{
+		return s_registeredVariables.at(variableName);
 	}
 }

--- a/Volt/Volt/src/Volt/Rendering/SceneRenderer.cpp
+++ b/Volt/Volt/src/Volt/Rendering/SceneRenderer.cpp
@@ -82,8 +82,6 @@
 
 namespace Volt
 {
-	static ConsoleVariable<int32_t> s_testCVar = ConsoleVariable<int32_t>("r.test", 0, "Test Variable");
-
 	namespace Utility
 	{
 		inline static Ref<RenderPipeline> CreateRenderPipeline(Ref<Shader> shader, std::vector<FramebufferAttachment> attachments, std::string_view name, CompareOperator depthCompare = CompareOperator::GreaterEqual)

--- a/Volt/Volt/src/Volt/Rendering/SceneRenderer.cpp
+++ b/Volt/Volt/src/Volt/Rendering/SceneRenderer.cpp
@@ -78,8 +78,12 @@
 #include "Volt/Utility/Noise.h"
 #include "Volt/Platform/ThreadUtility.h"
 
+#include "Volt/Console/ConsoleVariableRegistry.h"
+
 namespace Volt
 {
+	static ConsoleVariable<int32_t> s_testCVar = ConsoleVariable<int32_t>("r.test", 0, "Test Variable");
+
 	namespace Utility
 	{
 		inline static Ref<RenderPipeline> CreateRenderPipeline(Ref<Shader> shader, std::vector<FramebufferAttachment> attachments, std::string_view name, CompareOperator depthCompare = CompareOperator::GreaterEqual)

--- a/Volt/Volt/src/Volt/Rendering/SceneRenderer.cpp
+++ b/Volt/Volt/src/Volt/Rendering/SceneRenderer.cpp
@@ -78,8 +78,6 @@
 #include "Volt/Utility/Noise.h"
 #include "Volt/Platform/ThreadUtility.h"
 
-#include "Volt/Console/ConsoleVariableRegistry.h"
-
 namespace Volt
 {
 	namespace Utility


### PR DESCRIPTION
Implemented basic console variable support. Should be created in global scope, can be referenced in other compilation units using a reference

Usage:
```cpp
static ConsoleVariable<int32_t> s_testCVar = ConsoleVariable<int32_t>("r.test", 0, "Test Variable");

...

auto testValue = s_testVar.GetValue();
s_testVar = 4;
```

References should only be declared in functions/methods (for now)
Reference Usage:
```cpp
void TestFunc()
{
    static ConsoleVariableRef<int32_t> testCVarRef = ConsoleVariableRef<int32_t>("r.test");

    // Usage the same as original value.
}
```
